### PR TITLE
Fix the issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,14 +15,7 @@ Imports:
     gridExtra (>= 2.2.1)
 Depends:
     R (>= 3.2)
-Description: Implementation of sparse linear discriminant analysis, which is a supervised
-    classification method for multiple classes. Various novel optimization approaches to
-    this problem are implemented including alternating direction method of multipliers ('ADMM'),
-    proximal gradient (PG) and accelerated proximal gradient ('APG') (See Atkins 'et al'. <arXiv:1705.07194>).
-    Functions for performing cross validation are also supplied along with basic prediction
-    and plotting functions.
-    Sparse zero variance discriminant analysis ('SZVD') is also included in the package
-    (See Ames and Hong, <arXiv:1401.5492>). See the 'github' wiki for a more extended description.
+Description: Implementation of sparse linear discriminant analysis, which is a supervised classification method for multiple classes. Various novel optimization approaches to this problem are implemented including alternating direction method of multipliers ('ADMM'), proximal gradient (PG) and accelerated proximal gradient ('APG') (See Atkins 'et al'. <doi:10.48550/arXiv:1705.07194>). Functions for performing cross validation are also supplied along with basic prediction and plotting functions. Sparse zero variance discriminant analysis ('SZVD') is also included in the package (See Ames and Hong, <doi:10.48550/arXiv.1401.5492>). See the Github wiki for a more extended description.
 License: GPL (>= 2)
 URL: https://github.com/gumeo/accSDA/wiki
 BugReports: https://github.com/gumeo/accSDA/issues


### PR DESCRIPTION
The CRAN check produced a note regarding the Description field, indicating the use of arXiv identifiers and formatting issues. We have corrected the cross-references by replacing the arXiv identifiers with the recommended DOI format and removed unintended line breaks to improve clarity and compliance with CRAN guidelines.